### PR TITLE
Fix comment for mpd list sorting

### DIFF
--- a/mpd-add
+++ b/mpd-add
@@ -120,7 +120,7 @@ get_data() {
         fi
     fi
 
-    # Generate fresh data
+    # Case-insensitive sorting with special-character handling.
     case $mode in
         artist)
             # Case-insensitive sorting with special characters handling


### PR DESCRIPTION
## Summary
- clarify sorting comment in `mpd-add`

## Testing
- `bash -n mpd-add`
- `shellcheck mpd-add` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dae1c9f1c83309a888a187923d8d8