### PR TITLE
Update directory sorting comment

### DIFF
--- a/mpd-add
+++ b/mpd-add
@@ -127,7 +127,7 @@ get_data() {
             mpc list artist | LC_ALL=C sort -f | uniq | tee "$cache_file"
             ;;
         directory|new)
-            # Natural sorting for directories
+            # Case-insensitive alphabetical sorting for directories
             local base_dir=""
             [[ $mode == "new" ]] && base_dir="$NEW_DIR/"
 


### PR DESCRIPTION
## Summary
- clarify that directory sorting is case-insensitive alphabetical

## Testing
- `bash -n mpd-add`

------
https://chatgpt.com/codex/tasks/task_e_685dae22285c833083b811c64b61f58f